### PR TITLE
Set linguist to ignore vendored folders

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+server/spq_server/static/silk/* linguist-vendored
+


### PR DESCRIPTION
I changed `.gitattributes` so the language statistics don't show files from other projects